### PR TITLE
fix(desktop): Windows 卡死 + 报告无图 + 安装包未生成

### DIFF
--- a/.github/workflows/desktop-build.yml
+++ b/.github/workflows/desktop-build.yml
@@ -118,11 +118,25 @@ jobs:
           Invoke-WebRequest -Uri "https://github.com/eugeneware/ffmpeg-static/releases/download/b6.0/ffmpeg-win32-x64" -OutFile "desktop/bin/ffmpeg.exe"
           Invoke-WebRequest -Uri "https://github.com/eugeneware/ffmpeg-static/releases/download/b6.0/ffprobe-win32-x64" -OutFile "desktop/bin/ffprobe.exe"
 
-      - name: 打包
+      - name: 安装 Inno Setup
+        shell: pwsh
+        run: |
+          choco install innosetup --no-progress -y
+          # choco 安装在 Program Files (x86)，加入 PATH 供 ISCC 调用
+          $iscc = Get-ChildItem "C:\Program Files (x86)\Inno Setup 6\ISCC.exe" -ErrorAction SilentlyContinue
+          if (-not $iscc) { throw "Inno Setup 安装失败" }
+          Write-Host "ISCC: $($iscc.FullName)"
+
+      - name: 打包（含安装包）
         shell: pwsh
         run: |
           $env:PYTHON = "python"
+          $env:PATH = "C:\Program Files (x86)\Inno Setup 6;$env:PATH"
           powershell -ExecutionPolicy Bypass -File desktop/build_win.ps1
+          # 显式校验安装包产物，避免"回显成功但实际未生成"
+          $setup = Get-ChildItem desktop/dist -Filter "*-setup.exe"
+          if (-not $setup) { throw "未生成 Windows 安装包" }
+          Write-Host "安装包: $($setup.Name) ($([math]::Round($setup.Length/1MB,1)) MB)"
 
       - name: 冒烟测试（后端启动 + health）
         shell: pwsh
@@ -145,6 +159,12 @@ jobs:
         run: |
           $size = (Get-ChildItem -Recurse desktop/dist/VideoDevour | Measure-Object -Property Length -Sum).Sum
           Write-Host ("未压缩体积: {0:N1} MB" -f ($size / 1MB))
+
+      - uses: actions/upload-artifact@v4
+        with:
+          name: VideoDevour-windows-x64-installer
+          path: desktop/dist/*-setup.exe
+          retention-days: 14
 
       - uses: actions/upload-artifact@v4
         with:

--- a/.gitignore
+++ b/.gitignore
@@ -37,6 +37,7 @@ desktop/dist/
 desktop/build/
 desktop/bin/
 desktop/release/*.zip
+desktop/release/*.exe
 *.spec.bak
 
 # macOS

--- a/backend/algorithm/image_processor.py
+++ b/backend/algorithm/image_processor.py
@@ -140,10 +140,15 @@ def select_keyframes_with_vlm(headings_with_level, output_dir):
     """
     logging.info("--- 步骤 9: 开始使用 VLM 选择关键帧 ---")
     try:
-        from vlm_handler import VLMHandler
+        from backend.algorithm.vlm_handler import VLMHandler
         vlm_handler = VLMHandler()
     except Exception as e:
-        logging.error(f"无法初始化VLM处理器，跳过关键帧选择: {e}")
+        # 关键帧选择失败不阻断流程，但必须让用户知道报告将没有配图，
+        # 否则会表现为"处理成功但报告没图"的静默降级。
+        logging.error(
+            "VLM 关键帧选择不可用，本次报告将不含配图（其余内容正常生成）。"
+            f"原因: {e}。请检查「偏好设置」中的 VLM 配置（API Key / 接口地址 / 模型名）。"
+        )
         return {}
 
     selected_keyframes = {}

--- a/backend/algorithm/outline_handler.py
+++ b/backend/algorithm/outline_handler.py
@@ -335,7 +335,7 @@ def generate_final_report(detailed_outline_path, output_dir, education_level: st
         with open(detailed_outline_path, 'r', encoding='utf-8') as f:
             content = f.read()
 
-        from llm_handler import LLMHandler, get_level_instruction
+        from backend.algorithm.llm_handler import LLMHandler, get_level_instruction
         llm = LLMHandler(education_level=education_level)
 
         level_instruction = get_level_instruction(education_level)
@@ -638,7 +638,7 @@ def generate_detailed_report(detailed_outline_path, output_dir, education_level:
             return "\n".join(f"[{_mmss(c['start'])}] {c['text']}"
                              for c in chapter_chunks.get(heading, []))
 
-        from llm_handler import LLMHandler, get_level_instruction
+        from backend.algorithm.llm_handler import LLMHandler, get_level_instruction
         llm = LLMHandler(education_level=education_level)
         level_instruction = get_level_instruction(education_level) or ""
 

--- a/backend/algorithm/semantic_matcher.py
+++ b/backend/algorithm/semantic_matcher.py
@@ -195,7 +195,7 @@ class SemanticMatcher:
         
         return None, 0.0
 
-from llm_handler import LLMHandler
+from backend.algorithm.llm_handler import LLMHandler
 
 def match_chunk_to_headings_llm(chunk, headings, chunk_index=None, all_chunks=None, context_window=3):
     """

--- a/desktop/build_win.ps1
+++ b/desktop/build_win.ps1
@@ -55,8 +55,17 @@ Write-Host "[3/4] 检查 Inno Setup..."
 $Iscc = Get-Command iscc.exe -ErrorAction SilentlyContinue
 if ($Iscc) {
     Write-Host "[4/4] 生成安装包..."
+    # 检查 ISCC 退出码：之前只判断"命令是否存在"，
+    # 编译中止（如缺语言文件）也会打印"已生成"，导致误判。
     & $Iscc.Source (Join-Path $ScriptDir "installer.iss")
-    Write-Host "安装包已生成于 desktop\dist\"
+    if ($LASTEXITCODE -ne 0) {
+        throw "Inno Setup 编译失败（退出码 $LASTEXITCODE），详见上方输出"
+    }
+    $SetupExe = Get-ChildItem -Path $DistDir -Filter "*-setup.exe" | Select-Object -First 1
+    if (-not $SetupExe) {
+        throw "ISCC 返回成功但未找到 *-setup.exe，请检查 installer.iss 的 OutputDir"
+    }
+    Write-Host "安装包已生成：$($SetupExe.FullName)"
 } else {
     Write-Host "[4/4] 未检测到 Inno Setup，跳过安装包（目录版可直接运行）"
     Write-Host "      安装 Inno Setup 6 后重试：winget install JRSoftware.InnoSetup"

--- a/desktop/installer.iss
+++ b/desktop/installer.iss
@@ -31,7 +31,11 @@ WizardStyle=modern
 ; 卸载时不删除用户数据目录（任务、报告、设置保留）
 
 [Languages]
-Name: "chinesesimplified"; MessagesFile: "compiler:Languages\ChineseSimplified.isl"
+; 中文语言包随仓库内置（installer_lang/），不依赖 Inno Setup 安装目录或外网：
+; 官方安装只带英文语言文件，中文属独立翻译包，缺失会导致 "Couldn't open include file" 而中止编译。
+; {#SourcePath} 为脚本所在目录，避免相对路径解析歧义。
+Name: "chinesesimplified"; MessagesFile: "{#SourcePath}\installer_lang\ChineseSimplified.isl"
+Name: "english"; MessagesFile: "compiler:Default.isl"
 
 [Tasks]
 Name: "desktopicon"; Description: "创建桌面快捷方式"; GroupDescription: "附加任务:"

--- a/desktop/installer_lang/ChineseSimplified.isl
+++ b/desktop/installer_lang/ChineseSimplified.isl
@@ -1,0 +1,417 @@
+﻿; *** Inno Setup version 6.5.0+ Chinese Simplified messages ***
+;
+; To download user-contributed translations of this file, go to:
+;   https://jrsoftware.org/files/istrans/
+;
+; Note: When translating this text, do not add periods (.) to the end of
+; messages that didn't have them already, because on those messages Inno
+; Setup adds the periods automatically (appending a period would result in
+; two periods being displayed).
+;
+; Maintainer: Zhenghan Yang (Kira)
+; Email: 847320916@QQ.com
+; Github: https://github.com/kira-96/Inno-Setup-Chinese-Simplified-Translation
+; Encoding: UTF-8
+; Translation based on network resource
+;
+
+[LangOptions]
+; The following three entries are very important. Be sure to read and
+; understand the '[LangOptions] section' topic in the help file.
+LanguageName=简体中文
+; About LanguageID, to reference link:
+; https://docs.microsoft.com/en-us/openspecs/windows_protocols/ms-lcid/a9eac961-e77d-41a6-90a5-ce1a8b0cdb9c
+LanguageID=$0804
+; LanguageCodePage should always be set if possible, even if this file is Unicode
+; For English it's set to zero anyway because English only uses ASCII characters
+LanguageCodePage=936
+; If the language you are translating to requires special font faces or
+; sizes, uncomment any of the following entries and change them accordingly.
+;DialogFontName=
+;DialogFontSize=9
+;DialogFontBaseScaleWidth=7
+;DialogFontBaseScaleHeight=15
+;WelcomeFontName=Segoe UI
+;WelcomeFontSize=14
+
+[Messages]
+
+; *** Application titles
+SetupAppTitle=安装
+SetupWindowTitle=安装 - %1
+UninstallAppTitle=卸载
+UninstallAppFullTitle=%1 卸载
+
+; *** Misc. common
+InformationTitle=信息
+ConfirmTitle=确认
+ErrorTitle=错误
+
+; *** SetupLdr messages
+SetupLdrStartupMessage=现在将安装 %1。您想要继续吗？
+LdrCannotCreateTemp=无法创建临时文件。安装程序已中止
+LdrCannotExecTemp=无法执行临时目录中的文件。安装程序已中止
+HelpTextNote=
+
+; *** Startup error messages
+LastErrorMessage=%1。%n%n错误 %2: %3
+SetupFileMissing=安装目录中缺少文件 %1。请修正这个问题或者获取程序的新副本。
+SetupFileCorrupt=安装文件已损坏。请获取程序的新副本。
+SetupFileCorruptOrWrongVer=安装文件已损坏，或是与这个安装程序的版本不兼容。请修正这个问题或获取新的程序副本。
+InvalidParameter=无效的命令行参数：%n%n%1
+SetupAlreadyRunning=安装程序已在运行。
+WindowsVersionNotSupported=此程序不支持当前计算机运行的 Windows 版本。
+WindowsServicePackRequired=此程序需要 %1 服务包 %2 或更高版本。
+NotOnThisPlatform=此程序不能在 %1 上运行。
+OnlyOnThisPlatform=此程序只能在 %1 上运行。
+OnlyOnTheseArchitectures=此程序只能安装到为下列处理器架构设计的 Windows 版本中：%n%n%1
+WinVersionTooLowError=此程序需要 %1 版本 %2 或更高。
+WinVersionTooHighError=此程序不能安装于 %1 版本 %2 或更高。
+AdminPrivilegesRequired=在安装此程序时您必须以管理员身份登录。
+PowerUserPrivilegesRequired=在安装此程序时您必须以管理员身份或高级用户组身份登录。
+SetupAppRunningError=安装程序检测到 %1 当前正在运行。%n%n请先关闭正在运行的程序，然后点击“确定”继续，或点击“取消”退出。
+UninstallAppRunningError=卸载程序检测到 %1 当前正在运行。%n%n请先关闭正在运行的程序，然后点击“确定”继续，或点击“取消”退出。
+
+; *** Startup questions
+PrivilegesRequiredOverrideTitle=选择安装程序安装模式
+PrivilegesRequiredOverrideInstruction=选择安装模式
+PrivilegesRequiredOverrideText1=%1 可以为所有用户安装（需要管理员权限），或仅为您安装。
+PrivilegesRequiredOverrideText2=%1 可以仅为您安装，或为所有用户安装（需要管理员权限）。
+PrivilegesRequiredOverrideAllUsers=为所有用户安装(&A)
+PrivilegesRequiredOverrideAllUsersRecommended=为所有用户安装(&A)（推荐）
+PrivilegesRequiredOverrideCurrentUser=仅为我安装(&M)
+PrivilegesRequiredOverrideCurrentUserRecommended=仅为我安装(&M)（推荐）
+
+; *** Misc. errors
+ErrorCreatingDir=安装程序无法创建目录“%1”
+ErrorTooManyFilesInDir=无法在目录“%1”中创建文件，因为里面包含太多文件。
+
+; *** Setup common messages
+ExitSetupTitle=退出安装程序
+ExitSetupMessage=安装程序尚未完成。如果现在退出，将不会安装该程序。%n%n您之后可以再次运行安装程序完成安装。%n%n现在退出安装程序吗？
+AboutSetupMenuItem=关于安装程序(&A)...
+AboutSetupTitle=关于安装程序
+AboutSetupMessage=%1 版本 %2%n%3%n%n%1 主页：%n%4
+AboutSetupNote=
+TranslatorNote=简体中文翻译由 Kira（847320916@qq.com）维护。项目地址：https://github.com/kira-96/Inno-Setup-Chinese-Simplified-Translation
+
+; *** Buttons
+ButtonBack=< 上一步(&B)
+ButtonNext=下一步(&N) >
+ButtonInstall=安装(&I)
+ButtonOK=确定
+ButtonCancel=取消
+ButtonYes=是(&Y)
+ButtonYesToAll=全是(&A)
+ButtonNo=否(&N)
+ButtonNoToAll=全否(&O)
+ButtonFinish=完成(&F)
+ButtonBrowse=浏览(&B)...
+ButtonWizardBrowse=浏览(&R)...
+ButtonNewFolder=新建文件夹(&M)
+
+; *** "Select Language" dialog messages
+SelectLanguageTitle=选择安装语言
+SelectLanguageLabel=选择安装时使用的语言。
+
+; *** Common wizard text
+ClickNext=点击“下一步”继续，或点击“取消”退出安装程序。
+BeveledLabel=
+BrowseDialogTitle=浏览文件夹
+BrowseDialogLabel=在下面的列表中选择一个文件夹，然后点击“确定”。
+NewFolderName=新建文件夹
+
+; *** "Welcome" wizard page
+WelcomeLabel1=欢迎使用 [name] 安装向导
+WelcomeLabel2=即将在您的计算机上安装 [name/ver]。%n%n建议您在继续安装前关闭所有其他应用程序。
+
+; *** "Password" wizard page
+WizardPassword=密码
+PasswordLabel1=此安装程序需要密码验证。
+PasswordLabel3=请输入密码，然后点击“下一步”继续。密码区分大小写。
+PasswordEditLabel=密码(&P)：
+IncorrectPassword=您输入的密码不正确，请重新输入。
+
+; *** "License Agreement" wizard page
+WizardLicense=许可协议
+LicenseLabel=请在继续安装前阅读以下重要信息。
+LicenseLabel3=请阅读下列许可协议。在继续安装前您必须同意这些协议条款。
+LicenseAccepted=我同意此协议(&A)
+LicenseNotAccepted=我不同意此协议(&D)
+
+; *** "Information" wizard pages
+WizardInfoBefore=信息
+InfoBeforeLabel=请在继续安装前阅读以下重要信息。
+InfoBeforeClickLabel=准备好继续安装后，点击“下一步”。
+WizardInfoAfter=信息
+InfoAfterLabel=请在继续安装前阅读以下重要信息。
+InfoAfterClickLabel=准备好继续安装后，点击“下一步”。
+
+; *** "User Information" wizard page
+WizardUserInfo=用户信息
+UserInfoDesc=请输入您的信息。
+UserInfoName=用户名(&U)：
+UserInfoOrg=组织(&O)：
+UserInfoSerial=序列号(&S)：
+UserInfoNameRequired=请输入用户名。
+
+; *** "Select Destination Location" wizard page
+WizardSelectDir=选择目标位置
+SelectDirDesc=您想将 [name] 安装在哪里？
+SelectDirLabel3=安装程序将安装 [name] 到下面的文件夹中。
+SelectDirBrowseLabel=点击“下一步”继续。如果您想选择其他文件夹，点击“浏览”。
+DiskSpaceGBLabel=至少需要有 [gb] GB 的可用磁盘空间。
+DiskSpaceMBLabel=至少需要有 [mb] MB 的可用磁盘空间。
+CannotInstallToNetworkDrive=安装程序无法安装到一个网络驱动器。
+CannotInstallToUNCPath=安装程序无法安装到一个 UNC 路径。
+InvalidPath=您必须输入一个带驱动器盘符的完整路径，例如：%n%nC:\App%n%n或UNC路径：%n%n\\server\share
+InvalidDrive=您选定的驱动器或 UNC 共享不存在或不能访问。请选择其他位置。
+DiskSpaceWarningTitle=磁盘空间不足
+DiskSpaceWarning=安装程序至少需要 %1 KB 的可用空间才能安装，但选定驱动器只有 %2 KB 的可用空间。%n%n您确定要继续吗？
+DirNameTooLong=文件夹名称或路径太长。
+InvalidDirName=文件夹名称无效。
+BadDirName32=文件夹名称不能包含下列任何字符：%n%n%1
+DirExistsTitle=文件夹已存在
+DirExists=文件夹：%n%n%1%n%n已经存在。您确定安装到这个文件夹中吗？
+DirDoesntExistTitle=文件夹不存在
+DirDoesntExist=文件夹：%n%n%1%n%n不存在。您想要创建此文件夹吗？
+
+; *** "Select Components" wizard page
+WizardSelectComponents=选择组件
+SelectComponentsDesc=您想安装哪些程序组件？
+SelectComponentsLabel2=选中您想安装的组件；取消您不想安装的组件。然后点击“下一步”继续。
+FullInstallation=完全安装
+; if possible don't translate 'Compact' as 'Minimal' (I mean 'Minimal' in your language)
+CompactInstallation=简洁安装
+CustomInstallation=自定义安装
+NoUninstallWarningTitle=组件已存在
+NoUninstallWarning=安装程序检测到下列组件已安装在您的计算机中：%n%n%1%n%n取消选中这些组件不会卸载它们。%n%n您确定要继续吗？
+ComponentSize1=%1 KB
+ComponentSize2=%1 MB
+ComponentsDiskSpaceGBLabel=当前选择的组件需要至少 [gb] GB 的磁盘空间。
+ComponentsDiskSpaceMBLabel=当前选择的组件需要至少 [mb] MB 的磁盘空间。
+
+; *** "Select Additional Tasks" wizard page
+WizardSelectTasks=选择附加任务
+SelectTasksDesc=您想要安装程序执行哪些附加任务？
+SelectTasksLabel2=选择您想要安装程序在安装 [name] 时执行的附加任务，然后点击“下一步”。
+
+; *** "Select Start Menu Folder" wizard page
+WizardSelectProgramGroup=选择开始菜单文件夹
+SelectStartMenuFolderDesc=安装程序应该在哪里放置程序的快捷方式？
+SelectStartMenuFolderLabel3=安装程序将在下列“开始”菜单文件夹中创建程序的快捷方式。
+SelectStartMenuFolderBrowseLabel=点击“下一步”继续。如果您想选择其他文件夹，点击“浏览”。
+MustEnterGroupName=您必须输入一个文件夹名称。
+GroupNameTooLong=文件夹名称或路径太长。
+InvalidGroupName=文件夹名称无效。
+BadGroupName=文件夹名称不能包含下列任何字符：%n%n%1
+NoProgramGroupCheck2=不创建开始菜单文件夹(&D)
+
+; *** "Ready to Install" wizard page
+WizardReady=准备安装
+ReadyLabel1=安装程序准备就绪，现在可以开始安装 [name] 到您的计算机。
+ReadyLabel2a=点击“安装”继续此安装程序。如果您想重新查看或修改任何设置，点击“上一步”。
+ReadyLabel2b=点击“安装”继续此安装程序。
+ReadyMemoUserInfo=用户信息：
+ReadyMemoDir=目标位置：
+ReadyMemoType=安装类型：
+ReadyMemoComponents=已选择组件：
+ReadyMemoGroup=开始菜单文件夹：
+ReadyMemoTasks=附加任务：
+
+; *** TDownloadWizardPage wizard page and DownloadTemporaryFile
+DownloadingLabel2=正在下载文件...
+ButtonStopDownload=停止下载(&S)
+StopDownload=您确定要停止下载吗？
+ErrorDownloadAborted=下载已中止。
+ErrorDownloadFailed=下载失败：%1 %2。
+ErrorDownloadSizeFailed=获取大小失败：%1 %2。
+ErrorProgress=无效的进度：%1 / %2。
+ErrorFileSize=文件大小错误：预期 %1，实际 %2。
+
+; *** TExtractionWizardPage wizard page and ExtractArchive
+ExtractingLabel=正在提取文件...
+ButtonStopExtraction=停止提取(&S)
+StopExtraction=您确定要停止提取吗？
+ErrorExtractionAborted=提取已中止。
+ErrorExtractionFailed=提取失败：%1
+
+; *** Archive extraction failure details
+ArchiveIncorrectPassword=密码不正确。
+ArchiveIsCorrupted=压缩包已损坏。
+ArchiveUnsupportedFormat=不支持的压缩包格式。
+
+; *** "Preparing to Install" wizard page
+WizardPreparing=正在准备安装
+PreparingDesc=安装程序正在准备安装 [name] 到您的计算机。
+PreviousInstallNotCompleted=先前的程序安装或卸载未完成，需要您重启计算机以完成该安装。%n%n在重启计算机后，再次运行安装程序以完成 [name] 的安装。
+CannotContinue=安装程序不能继续。请点击“取消”退出。
+ApplicationsFound=以下应用程序正在使用将由安装程序更新的文件。建议您允许安装程序自动关闭这些应用程序。
+ApplicationsFound2=以下应用程序正在使用将由安装程序更新的文件。建议您允许安装程序自动关闭这些应用程序。安装完成后，安装程序将尝试重新启动这些应用程序。
+CloseApplications=自动关闭应用程序(&A)
+DontCloseApplications=不要关闭应用程序(&D)
+ErrorCloseApplications=安装程序无法自动关闭所有应用程序。建议您在继续之前，关闭所有在使用需要由安装程序更新的文件的应用程序。
+PrepareToInstallNeedsRestart=安装程序必须重启您的计算机。计算机重启后，请再次运行安装程序以完成 [name] 的安装。%n%n要立即重启吗？
+
+; *** "Installing" wizard page
+WizardInstalling=正在安装
+InstallingLabel=安装程序正在安装 [name] 到您的计算机，请稍候。
+
+; *** "Setup Completed" wizard page
+FinishedHeadingLabel=完成 [name] 安装向导
+FinishedLabelNoIcons=安装程序已在您的计算机中安装了 [name]。
+FinishedLabel=安装程序已在您的计算机中安装了 [name]。您可以通过已安装的快捷方式运行此应用程序。
+ClickFinish=点击“完成”退出安装程序。
+FinishedRestartLabel=为完成 [name] 的安装，安装程序必须重新启动您的计算机。要立即重启吗？
+FinishedRestartMessage=为完成 [name] 的安装，安装程序必须重新启动您的计算机。%n%n要立即重启吗？
+ShowReadmeCheck=是，我想查阅自述文件
+YesRadio=是，立即重启计算机(&Y)
+NoRadio=否，稍后重启计算机(&N)
+; used for example as 'Run MyProg.exe'
+RunEntryExec=运行 %1
+; used for example as 'View Readme.txt'
+RunEntryShellExec=查阅 %1
+
+; *** "Setup Needs the Next Disk" stuff
+ChangeDiskTitle=安装程序需要下一张磁盘
+SelectDiskLabel2=请插入磁盘 %1 并点击“确定”。%n%n如果这个磁盘中的文件可以在下列文件夹之外的文件夹中找到，请输入正确的路径或点击“浏览”。
+PathLabel=路径(&P)：
+FileNotInDir2=“%2”中找不到文件“%1”。请插入正确的磁盘或选择其他文件夹。
+SelectDirectoryLabel=请指定下一张磁盘的位置。
+
+; *** Installation phase messages
+SetupAborted=安装程序未完成安装。%n%n请修正这个问题并重新运行安装程序。
+AbortRetryIgnoreSelectAction=选择操作
+AbortRetryIgnoreRetry=重试(&T)
+AbortRetryIgnoreIgnore=忽略错误并继续(&I)
+AbortRetryIgnoreCancel=取消安装
+RetryCancelSelectAction=选择操作
+RetryCancelRetry=重试(&T)
+RetryCancelCancel=取消
+
+; *** Installation status messages
+StatusClosingApplications=正在关闭应用程序...
+StatusCreateDirs=正在创建目录...
+StatusExtractFiles=正在提取文件...
+StatusDownloadFiles=正在下载文件...
+StatusCreateIcons=正在创建快捷方式...
+StatusCreateIniEntries=正在创建 INI 条目...
+StatusCreateRegistryEntries=正在创建注册表条目...
+StatusRegisterFiles=正在注册文件...
+StatusSavingUninstall=正在保存卸载信息...
+StatusRunProgram=正在完成安装...
+StatusRestartingApplications=正在重启应用程序...
+StatusRollback=正在撤销更改...
+
+; *** Misc. errors
+ErrorInternal2=内部错误：%1。
+ErrorFunctionFailedNoCode=%1 失败。
+ErrorFunctionFailed=%1 失败；错误代码 %2。
+ErrorFunctionFailedWithMessage=%1 失败；错误代码 %2。%n%3
+ErrorExecutingProgram=无法执行文件：%n%1
+
+; *** Registry errors
+ErrorRegOpenKey=打开注册表项时出错：%n%1\%2
+ErrorRegCreateKey=创建注册表项时出错：%n%1\%2
+ErrorRegWriteKey=写入注册表项时出错：%n%1\%2
+
+; *** INI errors
+ErrorIniEntry=在文件“%1”中创建 INI 条目时出错。
+
+; *** File copying errors
+FileAbortRetryIgnoreSkipNotRecommended=跳过此文件(&S)（不推荐）
+FileAbortRetryIgnoreIgnoreNotRecommended=忽略错误并继续(&I)（不推荐）
+SourceIsCorrupted=源文件已损坏。
+SourceDoesntExist=源文件“%1”不存在。
+SourceVerificationFailed=源文件验证失败：%1
+VerificationSignatureDoesntExist=签名文件“%1”不存在。
+VerificationSignatureInvalid=签名文件“%1”无效。
+VerificationKeyNotFound=签名文件“%1”使用了未知的密钥。
+VerificationFileNameIncorrect=文件名不正确。
+VerificationFileTagIncorrect=文件标签不正确。
+VerificationFileSizeIncorrect=文件大小不正确。
+VerificationFileHashIncorrect=文件哈希值不正确。
+ExistingFileReadOnly2=无法替换已存在的文件，它是只读的。
+ExistingFileReadOnlyRetry=移除只读属性并重试(&R)
+ExistingFileReadOnlyKeepExisting=保留已存在的文件(&K)
+ErrorReadingExistingDest=尝试读取已存在的文件时出错：
+FileExistsSelectAction=选择操作
+FileExists2=文件已经存在。
+FileExistsOverwriteExisting=覆盖已存在的文件(&O)
+FileExistsKeepExisting=保留已存在的文件(&K)
+FileExistsOverwriteOrKeepAll=为接下来的冲突文件执行此操作(&D)
+ExistingFileNewerSelectAction=选择操作
+ExistingFileNewer2=已存在的文件比安装程序将要安装的文件还要新。
+ExistingFileNewerOverwriteExisting=覆盖已存在的文件(&O)
+ExistingFileNewerKeepExisting=保留已存在的文件(&K)（推荐）
+ExistingFileNewerOverwriteOrKeepAll=为接下来的冲突文件执行此操作(&D)
+ErrorChangingAttr=尝试更改下列已存在的文件属性时出错：
+ErrorCreatingTemp=尝试在目标目录创建文件时出错：
+ErrorReadingSource=尝试读取下列源文件时出错：
+ErrorCopying=尝试复制下列文件时出错：
+ErrorDownloading=尝试下载文件时出错：
+ErrorExtracting=尝试提取压缩包时出错：
+ErrorReplacingExistingFile=尝试替换已存在的文件时出错：
+ErrorRestartReplace=重启并替换失败：
+ErrorRenamingTemp=尝试重命名下列目标目录中的一个文件时出错：
+ErrorRegisterServer=无法注册 DLL/OCX：%1
+ErrorRegSvr32Failed=RegSvr32 失败；退出代码 %1。
+ErrorRegisterTypeLib=无法注册类型库：%1
+
+; *** Uninstall display name markings
+; used for example as 'My Program (32-bit)'
+UninstallDisplayNameMark=%1 (%2)
+; used for example as 'My Program (32-bit, All users)'
+UninstallDisplayNameMarks=%1 (%2, %3)
+UninstallDisplayNameMark32Bit=32 位
+UninstallDisplayNameMark64Bit=64 位
+UninstallDisplayNameMarkAllUsers=所有用户
+UninstallDisplayNameMarkCurrentUser=当前用户
+
+; *** Post-installation errors
+ErrorOpeningReadme=尝试打开自述文件时出错。
+ErrorRestartingComputer=安装程序无法重启计算机，请手动重启。
+
+; *** Uninstaller messages
+UninstallNotFound=文件“%1”不存在。无法卸载。
+UninstallOpenError=文件“%1”不能被打开。无法卸载
+UninstallUnsupportedVer=此版本的卸载程序无法识别卸载日志文件“%1”的格式。无法卸载。
+UninstallUnknownEntry=卸载日志中遇到一个未知条目（%1）。
+ConfirmUninstall=您确认要完全移除 %1 及其所有组件吗？
+UninstallOnlyOnWin64=仅允许在 64 位 Windows 中卸载此程序。
+OnlyAdminCanUninstall=仅使用管理员权限的用户能完成此卸载。
+UninstallStatusLabel=正在从您的计算机中移除 %1，请稍候。
+UninstalledAll=已顺利从您的计算机中移除 %1。
+UninstalledMost=%1 卸载完成。%n%n有部分内容未能被删除，但您可以手动删除它们。
+UninstalledAndNeedsRestart=为完成 %1 的卸载，需要重启您的计算机。%n%n要立即重启吗？
+UninstallDataCorrupted=文件“%1”已损坏。无法卸载。
+
+; *** Uninstallation phase messages
+ConfirmDeleteSharedFileTitle=删除共享文件？
+ConfirmDeleteSharedFile2=系统表示下列共享文件已不再有任何程序使用。您希望卸载程序删除此共享文件吗？%n%n如果仍有程序正在使用此文件，删除后这些程序可能无法正常运行。如果您不能确定，请选择“否”，保留此文件在系统中不会造成任何损害。
+SharedFileNameLabel=文件名：
+SharedFileLocationLabel=位置：
+WizardUninstalling=卸载状态
+StatusUninstalling=正在卸载 %1...
+
+; *** Shutdown block reasons
+ShutdownBlockReasonInstallingApp=正在安装 %1。
+ShutdownBlockReasonUninstallingApp=正在卸载 %1。
+
+; The custom messages below aren't used by Setup itself, but if you make
+; use of them in your scripts, you'll want to translate them.
+
+[CustomMessages]
+
+NameAndVersion=%1 版本 %2
+AdditionalIcons=附加快捷方式：
+CreateDesktopIcon=创建桌面快捷方式(&D)
+CreateQuickLaunchIcon=创建快速启动栏快捷方式(&Q)
+ProgramOnTheWeb=%1 网站
+UninstallProgram=卸载 %1
+LaunchProgram=运行 %1
+AssocFileExtension=将 %2 文件扩展名与 %1 建立关联(&A)
+AssocingFileExtension=正在将 %2 文件扩展名与 %1 建立关联...
+AutoStartProgramGroupDescription=启动：
+AutoStartProgram=自动启动 %1
+AddonHostProgramNotFound=您选择的文件夹中无法找到 %1。%n%n您确定要继续吗？

--- a/desktop/release/README-测试说明.md
+++ b/desktop/release/README-测试说明.md
@@ -1,15 +1,40 @@
 # VideoDevour 桌面客户端 · 测试包
 
-构建日期：2026-09-09　版本：0.1.0（轻量包）
+构建日期：2026-09-11　版本：0.1.0（轻量包）
 
 ## 交付文件
 
 | 文件 | 平台 | 大小 | 说明 |
 |------|------|------|------|
-| `VideoDevour-macos-arm64.zip` | macOS Apple Silicon | 192MB | 解压后得到 `VideoDevour.app` |
-| `VideoDevour-windows-x64.zip` | Windows x64 | 200MB | 解压后得到 `VideoDevour.exe` + `_internal/` |
+| `VideoDevour-0.1.0-setup.exe` | Windows x64 | 146MB | **推荐**：安装程序，含开始菜单/桌面快捷方式 |
+| `VideoDevour-windows-x64.zip` | Windows x64 | 203MB | 绿色版，解压即用（免安装） |
+| `VideoDevour-macos-arm64.zip` | macOS Apple Silicon | 195MB | 解压后得到 `VideoDevour.app` |
 
-> **必须解压后运行**：两个包都是 onedir 结构，不能只单独拿出 `.app` / `.exe`。
+> **绿色版必须解压后运行**：含 onedir 结构，不能只单独拿出 `.exe`。
+
+## Windows 测试步骤
+
+### 方式一：安装包（推荐）
+
+1. 双击 `VideoDevour-0.1.0-setup.exe`
+2. 按向导安装（默认装到 `%LOCALAPPDATA%\Programs\VideoDevour`，免管理员权限）
+3. 从开始菜单或桌面快捷方式启动
+
+**卸载时用户数据会保留**（任务、报告、设置都在 `%LOCALAPPDATA%\VideoDevour`）。
+
+### 方式二：绿色版
+
+```powershell
+Expand-Archive VideoDevour-windows-x64.zip -DestinationPath .
+.\VideoDevour.exe
+```
+
+### SmartScreen 提示
+
+两种方式首次运行都会弹"Windows 已保护你的电脑"——因为**安装包与可执行文件都未做代码签名**。
+点「更多信息」→「仍要运行」即可。这是预期行为，正式发行前会加签名证书。
+
+**系统要求**：Windows 10/11 x64 + WebView2 运行时（Win11 及较新版 Win10 已内置）。
 
 ## macOS 测试步骤
 
@@ -27,20 +52,6 @@ open VideoDevour.app
 若双击提示"已损坏"或"无法验证开发者"，就是第 2 步没做。
 
 **适用机型**：Apple Silicon（M1/M2/M3/M4）。Intel Mac 不适用（本次未构建 x86_64）。
-
-## Windows 测试步骤
-
-```powershell
-# 1. 解压到任意目录（不要放在 C:\Program Files 等受保护路径）
-Expand-Archive VideoDevour-windows-x64.zip -DestinationPath .
-
-# 2. 运行
-.\VideoDevour.exe
-```
-
-**系统要求**：Windows 10/11 x64，需要 **WebView2 运行时**（Win11 及较新的 Win10 已内置；若提示缺失，从微软官网安装 Evergreen 版）。
-
-**SmartScreen 提示**：包未做代码签名，首次运行会弹"Windows 已保护你的电脑"→ 点"更多信息"→"仍要运行"。这是预期行为，正式发行前会加签名证书。
 
 ## 首次使用要配置的东西
 

--- a/desktop/shell.py
+++ b/desktop/shell.py
@@ -180,14 +180,24 @@ class BackendProcess:
 
 
 class Bridge:
-    """暴露给前端的原生桥（仅文件操作与窗口操作）。"""
+    """
+    暴露给前端的原生桥（仅文件操作与窗口操作）。
+
+    注意：窗口引用必须是下划线私有属性（`_window`）。
+    pywebview 注入 js_api 时会递归展开对象的**公开**属性（webview/util.py 的
+    get_functions），只跳过下划线开头的名字。若窗口引用是公开属性（如 `self.window`），
+    它会一路走进原生窗口对象图：
+        window.native.AccessibilityObject.Bounds.Empty.Empty.Empty...
+    WinForms 的 `Rectangle.Empty` 每次返回新实例，pywebview 靠 id() 去重因此失效，
+    导致无限递归（Windows 实测：窗口卡死、终端刷满 maximum recursion depth exceeded）。
+    """
 
     def __init__(self, window=None):
-        self.window = window
+        self._window = window
 
     def pick_video(self):
         """选择视频文件，返回绝对路径。"""
-        result = self.window.create_file_dialog(
+        result = self._window.create_file_dialog(
             webview.OPEN_DIALOG,
             allow_multiple=False,
             file_types=("视频文件 (*.mp4;*.mov;*.mkv;*.avi;*.webm;*.flv;*.m4v)", "所有文件 (*.*)"),
@@ -196,7 +206,7 @@ class Bridge:
 
     def save_as(self, suggested_name: str = "export.md", content: str = ""):
         """另存为：返回保存路径。"""
-        result = self.window.create_file_dialog(
+        result = self._window.create_file_dialog(
             webview.SAVE_DIALOG, save_filename=suggested_name
         )
         if not result:
@@ -306,7 +316,8 @@ def main():
         height=860,
         min_size=(900, 600),
     )
-    bridge.window = window
+    # 赋给私有属性（不可写成 bridge.window，否则触发 pywebview 递归展开原生窗口对象）
+    bridge._window = window
 
     def _on_closed():
         backend.stop()

--- a/desktop/videodevour.spec
+++ b/desktop/videodevour.spec
@@ -71,8 +71,26 @@ hiddenimports += collect_submodules("yt_dlp")
 hiddenimports += collect_submodules("reportlab")
 datas += collect_data_files("reportlab")
 
-# 项目自身的后端包（避免遗漏子模块）
-hiddenimports += collect_submodules("backend")
+# 项目自身的后端模块：用文件系统枚举，不要依赖 collect_submodules。
+# 原因：backend/、backend/algorithm/、backend/devour/ 都没有 __init__.py（隐式命名空间包），
+# collect_submodules("backend") 只会返回 backend.api / backend.runtime 两个包下的模块
+# （实测 5 个），algorithm 与 devour 下的模块一个都收不到。
+# 之前能运行只是碰巧：PyInstaller 顺着入口的静态 import 链收到了大部分模块，
+# 而仅被“函数内裸导入”引用的模块（如 vlm_handler）被静默漏掉，
+# 表现为关键帧选择失败、报告无图。
+def _iter_backend_modules():
+    names = set()
+    for py in (PROJECT_ROOT / "backend").rglob("*.py"):
+        if py.name == "__init__.py":
+            continue
+        if py.name.startswith("test_") or py.name == "config.template.py":
+            continue
+        rel = py.relative_to(PROJECT_ROOT).with_suffix("")
+        names.add(".".join(rel.parts))
+    return sorted(names)
+
+
+hiddenimports += _iter_backend_modules()
 hiddenimports += collect_submodules("desktop")
 
 # pywebview 在 macOS 下依赖 pyobjc WebKit 桥，需显式收集

--- a/planning/A3-A4-构建验证报告.md
+++ b/planning/A3-A4-构建验证报告.md
@@ -166,6 +166,44 @@ WinForms 的 `Rectangle.Empty` **每次访问返回新实例**，而 pywebview �
 > **通用教训**：凡是传给 `js_api` 的对象，其**公开**属性都会被 pywebview 递归内省；
 > 任何指向原生/外部框架对象的引用都必须用下划线私有属性，或加 `_serializable = False`。
 
+### 4.4 macOS 客户端报告无图：PyInstaller 漏收 vlm_handler（2026-09-11）
+
+macOS 客户端处理完成后**报告里没有配图**，日志中出现唯一一条 ERROR：
+
+```
+ERROR - 无法初始化VLM处理器，跳过关键帧选择: No module named 'vlm_handler'
+```
+
+**两层根因**：
+
+1. **`collect_submodules("backend")` 实际失效**：`backend/`、`backend/algorithm/`、`backend/devour/`
+   都没有 `__init__.py`（隐式命名空间包），该调用只返回 `backend.api` 与 `backend.runtime`
+   下的 5 个模块，`algorithm`/`devour` 一个都收不到。
+   之前能运行只是碰巧——PyInstaller 顺着入口的静态 import 链收到了大部分模块。
+2. **裸导入无法被静态分析**：`image_processor.py` 用 `from vlm_handler import VLMHandler`
+   （函数内裸导入，依赖 `settings_store` 往 `sys.path` 插入 `backend/algorithm`）。
+   冻结后代码都在 PYZ 归档里，该目录在磁盘上不存在，`sys.path` 插入无效。
+   只被这种裸导入引用的 `vlm_handler` 因此被静默漏掉，而 `llm_handler` 因别处有
+   `backend.algorithm.llm_handler` 的静态导入而侥幸收录——这正是"报告能生成但没图"的原因。
+
+| # | 问题 | 修复 |
+|---|------|------|
+| 14 | 命名空间包导致 `collect_submodules("backend")` 失效 | spec 改为文件系统枚举 `backend/**/*.py` |
+| 15 | 项目内裸导入在冻结包中失效（4 处） | 统一改为绝对导入 `backend.algorithm.*` |
+| 16 | VLM 不可用时静默降级（用户只看到"处理成功"） | 错误信息改为可操作提示，明确说明"报告将不含配图" |
+
+**验证**（macOS 冻结包，PATH 限制、无 torch）：
+
+| 项 | 结果 |
+|----|------|
+| PYZ 收录 `backend.algorithm.*` | 16 → 20 个模块，含 `vlm_handler` |
+| VLM 实际执行 | ✅ 每章 7-8 帧评分，选定 3 张关键帧 |
+| 报告图片引用 | ✅ `![关键帧: ...](keyframes/01_xxx.jpg)` |
+| 图片 HTTP 可访问 | ✅ `/static/<out_dir>/keyframes/<中文名>` → 200 image/jpeg |
+
+> **通用教训**：spec 里不要对无 `__init__.py` 的目录用 `collect_submodules`；
+> 项目内导入一律用绝对路径，避免依赖 `sys.path` 副作用（冻结后不成立）。
+
 ---
 
 ## 5. 已实现的能力（对照方案条款）

--- a/planning/A3-A4-构建验证报告.md
+++ b/planning/A3-A4-构建验证报告.md
@@ -133,6 +133,39 @@ PyInstaller 静态分析无法发现，导致 `reportlab` 整个包未被收集�
 | 衍生文体生成（量子速读） | ✅ generated |
 | 衍生文体下载与 PDF 导出 | ✅ 1 页 PDF |
 
+### 4.3 Windows 真机致命缺陷：窗口卡死（2026-09-11）
+
+Windows 测试包一点击就卡死，终端刷满数百行
+`Error while processing window.native.AccessibilityObject.Bounds.Empty.Empty...: maximum recursion depth exceeded`。
+
+**根因（我们自己的代码）**：`desktop/shell.py` 的 `Bridge` 把 pywebview 的窗口对象存为**公开属性** `self.window`。
+pywebview 注入 js_api 时会递归展开对象的**公开**属性（`webview/util.py::get_functions`，仅跳过下划线开头的名字），
+于是走进原生窗口对象图：
+
+```
+window.native.AccessibilityObject.Bounds.Empty.Empty.Empty...
+```
+
+WinForms 的 `Rectangle.Empty` **每次访问返回新实例**，而 pywebview 靠 `id()` 去重，因此去重完全失效 → 无限递归。
+`get_functions` 的 `except Exception` 会逐层捕获 `RecursionError` 并各打印一条，所以终端出现数百行重复错误；
+同时注入线程卡死，`_pywebviewready` 事件永不触发，页面无法交互（表现为"卡住"）。
+
+> macOS 走同一注入函数但不受影响：PyObjC 对象图不会无限自我引用。
+
+| # | 问题 | 修复 |
+|---|------|------|
+| 13 | js_api 对象的公开属性指向原生窗口 → pywebview 无限递归 | 窗口引用改为私有属性 `_window`，并加注释说明约束 |
+
+**验证**：用 pywebview 真实的 `get_functions` 逻辑 + 模拟 WinForms `Rectangle.Empty` 行为做对照测试：
+
+| 场景 | 结果 |
+|------|------|
+| 修复后 `Bridge`（`_window` 指向原生窗口） | ✅ 稳定暴露 `pick_video/save_as/open_path`，无递归 |
+| 回归旧写法（公开 `window`） | ✗ 复现 `RecursionError` |
+
+> **通用教训**：凡是传给 `js_api` 的对象，其**公开**属性都会被 pywebview 递归内省；
+> 任何指向原生/外部框架对象的引用都必须用下划线私有属性，或加 `_serializable = False`。
+
 ---
 
 ## 5. 已实现的能力（对照方案条款）


### PR DESCRIPTION
## 三个 Windows/macOS 真机缺陷的修复

### 1. Windows 一点击就卡死（最严重）

**现象**：终端刷满 `window.native.AccessibilityObject.Bounds.Empty.Empty...: maximum recursion depth exceeded`

**根因（我们的代码）**：`Bridge` 把 pywebview 窗口对象存为**公开属性** `self.window`。pywebview 注入 js_api 时递归展开对象的公开属性（`webview/util.py::get_functions`，只跳过下划线名），于是走进原生窗口对象图；WinForms 的 `Rectangle.Empty` 每次返回新实例，pywebview 的 `id()` 去重失效 → 无限递归；`except Exception` 逐层捕获 `RecursionError` 各打印一条，注入线程卡死使 `_pywebviewready` 永不触发。

**修复**：窗口引用改为私有 `_window`。

### 2. 报告没有配图（macOS 实测）

**现象**：日志唯一 ERROR 为 `无法初始化VLM处理器，跳过关键帧选择: No module named 'vlm_handler'`

**两层根因**：
- `collect_submodules("backend")` **实际失效**：`backend/`、`backend/algorithm/`、`backend/devour/` 都无 `__init__.py`（隐式命名空间包），该调用只返回 `backend.api`/`backend.runtime` 下 5 个模块。此前能跑是碰巧靠静态 import 链收集
- 项目内**裸导入**（4 处）依赖 `sys.path` 插入 `backend/algorithm`，冻结后代码在 PYZ 内、该目录不存在，故失效；仅被裸导入引用的 `vlm_handler` 被静默漏掉，而 `llm_handler` 因别处有静态导入而侥幸收录——这正是"报告能生成但没图"的原因

**修复**：spec 改为文件系统枚举 `backend/**/*.py`；4 处裸导入改绝对导入；VLM 不可用时提示改为可操作信息。

### 3. 安装包从未真正生成

CI 实际为 `Compile aborted`（缺 `ChineseSimplified.isl`），但脚本无条件打印"已生成"、CI 又只上传目录版 zip。

**修复**：内置语言包（UTF-8 BOM）+ 保留英文回退；脚本校验 ISCC 退出码与产物；CI 上传 installer artifact。

## 验证

CI run 34608156995：macOS arm64 ✅ / Windows x64 ✅

macOS 冻结包（PATH 限制、无 torch）实测：
- `backend.algorithm.*` 收录由 16 增至 **20** 个模块（含 `vlm_handler`）
- VLM 实际执行：每章 7-8 帧评分，选定 3 张关键帧
- 报告含 `![关键帧: ...](keyframes/01_xxx.jpg)`
- `/static/<out_dir>/keyframes/<中文名>` → 200 image/jpeg

> ⚠️ Windows 侧 CI 仅验证启动与 health，业务链路请在真机确认。
