### PR TITLE
feat(desktop): 支持 macOS Intel (x86_64) 构建

### DIFF
--- a/.github/workflows/desktop-build.yml
+++ b/.github/workflows/desktop-build.yml
@@ -27,7 +27,9 @@ on:
       - "requirements-lite.txt"
 
 jobs:
-  build-macos:
+  # macOS 双架构：arm64 用 Apple Silicon runner，x86_64 用 Intel runner。
+  # 不在 arm64 上用 Rosetta 构建 x86_64——CI runner 无 Rosetta，且原生构建更可靠。
+  build-macos-arm64:
     name: macOS arm64
     runs-on: macos-14
     steps:
@@ -54,36 +56,98 @@ jobs:
 
       - name: 获取静态 ffmpeg（arm64）
         run: |
-          mkdir -p desktop/bin
-          curl -fL -o desktop/bin/ffmpeg \
-            https://github.com/eugeneware/ffmpeg-static/releases/download/b6.0/ffmpeg-darwin-arm64
-          curl -fL -o desktop/bin/ffprobe \
-            https://github.com/eugeneware/ffmpeg-static/releases/download/b6.0/ffprobe-darwin-arm64
-          chmod +x desktop/bin/ffmpeg desktop/bin/ffprobe
-          file desktop/bin/ffmpeg
+          bash desktop/fetch_binaries.sh macos-arm64
+          file desktop/bin/macos-arm64/ffmpeg
 
       - name: 打包 .app
         run: |
           chmod +x desktop/build_mac.sh
-          PYTHON=python ./desktop/build_mac.sh --sign
+          PYTHON_ARM64=python ./desktop/build_mac.sh --arm64 --sign
 
       - name: 冒烟测试（后端启动 + health）
         run: |
-          ./desktop/dist/VideoDevour.app/Contents/Resources/VideoDevour --backend-only \
+          ./desktop/dist/arm64/VideoDevour.app/Contents/Resources/VideoDevour --backend-only \
             --port 0 --data-dir "$RUNNER_TEMP/vd-data" \
             --handshake-file "$RUNNER_TEMP/hs.json" > /dev/null 2>&1 &
-          for i in $(seq 1 60); do [ -f "$RUNNER_TEMP/hs.json" ] && break; sleep 1; done
+          for i in $(seq 1 90); do [ -f "$RUNNER_TEMP/hs.json" ] && break; sleep 1; done
           PORT=$(python -c "import json;print(json.load(open('$RUNNER_TEMP/hs.json'))['port'])")
           curl -f "http://127.0.0.1:$PORT/api/health"
           curl -f -o /dev/null "http://127.0.0.1:$PORT/"
 
+      - name: 校验架构
+        run: file desktop/dist/arm64/VideoDevour.app/Contents/Resources/VideoDevour
+
       - name: 记录体积
-        run: du -sh desktop/dist/VideoDevour.app
+        run: du -sh desktop/dist/arm64/VideoDevour.app
 
       - uses: actions/upload-artifact@v4
         with:
           name: VideoDevour-macos-arm64
-          path: desktop/dist/VideoDevour.app
+          path: desktop/dist/arm64/VideoDevour.app
+          retention-days: 14
+
+  build-macos-x64:
+    name: macOS x86_64 (Intel)
+    runs-on: macos-13
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+
+      - name: 安装依赖
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r requirements-lite.txt pyinstaller pywebview
+
+      - name: 构建前端
+        run: |
+          cd frontend
+          npm ci || npm install
+          npm run build
+
+      - name: 获取静态 ffmpeg（x86_64）
+        run: |
+          bash desktop/fetch_binaries.sh macos-x64
+          file desktop/bin/macos-x64/ffmpeg
+
+      - name: 打包 .app
+        run: |
+          chmod +x desktop/build_mac.sh
+          PYTHON_X64=python ./desktop/build_mac.sh --x64 --sign
+
+      - name: 冒烟测试（后端启动 + health）
+        run: |
+          ./desktop/dist/x64/VideoDevour.app/Contents/Resources/VideoDevour --backend-only \
+            --port 0 --data-dir "$RUNNER_TEMP/vd-data" \
+            --handshake-file "$RUNNER_TEMP/hs.json" > /dev/null 2>&1 &
+          for i in $(seq 1 90); do [ -f "$RUNNER_TEMP/hs.json" ] && break; sleep 1; done
+          PORT=$(python -c "import json;print(json.load(open('$RUNNER_TEMP/hs.json'))['port'])")
+          curl -f "http://127.0.0.1:$PORT/api/health"
+          curl -f -o /dev/null "http://127.0.0.1:$PORT/"
+
+      - name: 校验架构与 cryptography（x64 曾因 OpenSSL 符号缺失失败）
+        run: |
+          file desktop/dist/x64/VideoDevour.app/Contents/Resources/VideoDevour
+          python - <<'PY'
+          import glob
+          so = glob.glob("desktop/dist/x64/VideoDevour.app/Contents/Resources/_internal/cryptography/hazmat/bindings/_rust.abi3.so")
+          assert so, "缺少 cryptography rust binding"
+          print("cryptography binding 已打包:", so[0])
+          PY
+
+      - name: 记录体积
+        run: du -sh desktop/dist/x64/VideoDevour.app
+
+      - uses: actions/upload-artifact@v4
+        with:
+          name: VideoDevour-macos-x64
+          path: desktop/dist/x64/VideoDevour.app
           retention-days: 14
 
   build-windows:
@@ -114,9 +178,9 @@ jobs:
       - name: 获取静态 ffmpeg（win64）
         shell: pwsh
         run: |
-          New-Item -ItemType Directory -Force -Path desktop/bin | Out-Null
-          Invoke-WebRequest -Uri "https://github.com/eugeneware/ffmpeg-static/releases/download/b6.0/ffmpeg-win32-x64" -OutFile "desktop/bin/ffmpeg.exe"
-          Invoke-WebRequest -Uri "https://github.com/eugeneware/ffmpeg-static/releases/download/b6.0/ffprobe-win32-x64" -OutFile "desktop/bin/ffprobe.exe"
+          New-Item -ItemType Directory -Force -Path "desktop/bin/windows-x64" | Out-Null
+          Invoke-WebRequest -Uri "https://github.com/eugeneware/ffmpeg-static/releases/download/b6.0/ffmpeg-win32-x64" -OutFile "desktop/bin/windows-x64/ffmpeg.exe"
+          Invoke-WebRequest -Uri "https://github.com/eugeneware/ffmpeg-static/releases/download/b6.0/ffprobe-win32-x64" -OutFile "desktop/bin/windows-x64/ffprobe.exe"
 
       - name: 安装 Inno Setup
         shell: pwsh

--- a/.github/workflows/desktop-build.yml
+++ b/.github/workflows/desktop-build.yml
@@ -88,7 +88,8 @@ jobs:
 
   build-macos-x64:
     name: macOS x86_64 (Intel)
-    runs-on: macos-13
+    # macos-13 已被 GitHub 弃用（job 会永久 queued）；当前 Intel runner 为 macos-15-intel
+    runs-on: macos-15-intel
     steps:
       - uses: actions/checkout@v4
 

--- a/desktop/README.md
+++ b/desktop/README.md
@@ -27,27 +27,43 @@ desktop/
 
 ## 构建
 
-### macOS（arm64）
+### macOS（arm64 / x86_64 双架构）
+
+两个架构必须用**各自架构的 Python** 构建（PyInstaller 的输出架构由解释器决定）。
 
 ```bash
-# 1. 轻量依赖
+# 1. 依赖环境
+#    arm64（Apple Silicon 本机）
 uv venv .venv-lite --python 3.12
 uv pip install --python .venv-lite/bin/python -r requirements-lite.txt pyinstaller pywebview
 
-# 2. 静态 ffmpeg/ffprobe
-./desktop/fetch_binaries.sh
+#    x86_64（Intel；在 Apple Silicon 上经 uv 安装 x86_64 Python）
+uv python install cpython-3.12.13-macos-x86_64-none
+uv venv .venv-x64 --python cpython-3.12.13-macos-x86_64-none
+uv pip install --python .venv-x64/bin/python -r requirements-lite.txt pyinstaller pywebview
 
-# 3. 前端
+# 2. 静态 ffmpeg/ffprobe（按架构分目录存放，双架构可共存）
+./desktop/fetch_binaries.sh --all-macos
+
+# 3. 前端（两架构共用）
 cd frontend && npm run build && cd ..
 
 # 4. 打包
-PYTHON=.venv-lite/bin/python ./desktop/build_mac.sh --sign
+PYTHON_ARM64=.venv-lite/bin/python ./desktop/build_mac.sh --arm64 --sign
+PYTHON_X64=.venv-x64/bin/python   ./desktop/build_mac.sh --x64 --sign
+# 或一次构建两个架构：./desktop/build_mac.sh --both --sign
 
 # 5. 运行
-open desktop/dist/VideoDevour.app
+open desktop/dist/arm64/VideoDevour.app   # Apple Silicon
+open desktop/dist/x64/VideoDevour.app     # Intel
 ```
 
-内测被 Gatekeeper 拦截时：`xattr -cr desktop/dist/VideoDevour.app`（**仅限内测**，正式分发需公证）。
+产物分别在 `desktop/dist/arm64/` 与 `desktop/dist/x64/`。
+
+内测被 Gatekeeper 拦截时：`xattr -cr '<app 路径>'`（**仅限内测**，正式分发需公证）。
+
+> **不要用 `--universal2`**：torch 等依赖不做 universal2，且本包依赖的二进制 wheel
+> 各有架构限制，`lipo` 合并不可行。
 
 ### Windows（x64）
 

--- a/desktop/build_mac.sh
+++ b/desktop/build_mac.sh
@@ -1,58 +1,105 @@
 #!/bin/bash
-# VideoDevour macOS 构建脚本（arm64）
+# VideoDevour macOS 构建脚本（支持 arm64 / x86_64）
 #
 # 用法：
-#   desktop/build_mac.sh            # 构建 + 组装 .app
-#   desktop/build_mac.sh --sign    # 额外做 ad-hoc 签名
+#   desktop/build_mac.sh                        # 按当前主机架构构建
+#   desktop/build_mac.sh --arm64                # Apple Silicon
+#   desktop/build_mac.sh --x64                  # Intel
+#   desktop/build_mac.sh --both --sign          # 双架构都构建 + ad-hoc 签名
 #
-# 产物：desktop/dist/VideoDevour.app
+# 产物：
+#   desktop/dist/arm64/VideoDevour.app
+#   desktop/dist/x64/VideoDevour.app
 #
 # 前置：
 #   - 前端已构建（frontend/dist）或本脚本自动构建
-#   - 轻量依赖已安装（requirements-lite.txt）+ pyinstaller + pywebview
-#   - desktop/bin/ 下已放置 arm64 静态 ffmpeg / ffprobe
+#   - 对应架构的 Python 环境与轻量依赖：
+#       arm64 → .venv-lite（可用 PYTHON_ARM64 覆盖）
+#       x64   → .venv-x64 （可用 PYTHON_X64 覆盖）
+#   - desktop/bin/<target>/ 下已放置对应架构静态 ffmpeg / ffprobe
+#     （运行 desktop/fetch_binaries.sh --all-macos 一次备齐）
 
 set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-PROJECT_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
-DIST_DIR="$SCRIPT_DIR/dist"
+PROJECT_ROOT="$(cd "${SCRIPT_DIR}/.." && pwd)"
 APP_NAME="VideoDevour"
-APP_BUNDLE="$DIST_DIR/$APP_NAME.app"
-PYTHON="${PYTHON:-$PROJECT_ROOT/.venv/bin/python}"
 
-DO_SIGN="${1:-}"
+BUILD_ARM64=0
+BUILD_X64=0
+DO_SIGN=0
 
-echo "=========================================="
-echo "  VideoDevour macOS 构建 (arm64)"
-echo "=========================================="
-
-# 1. 前端产物
-if [ ! -f "$PROJECT_ROOT/frontend/dist/index.html" ]; then
-  echo "[1/4] 构建前端..."
-  (cd "$PROJECT_ROOT/frontend" && npm run build)
-else
-  echo "[1/4] 前端产物已存在，跳过"
-fi
-
-# 2. 检查捆绑二进制
-for bin in ffmpeg ffprobe; do
-  if [ ! -f "$SCRIPT_DIR/bin/$bin" ]; then
-    echo "[警告] 缺少 desktop/bin/$bin，将回退系统 PATH"
-  fi
+for arg in "$@"; do
+  case "${arg}" in
+    --arm64) BUILD_ARM64=1 ;;
+    --x64)   BUILD_X64=1 ;;
+    --both)  BUILD_ARM64=1; BUILD_X64=1 ;;
+    --sign)  DO_SIGN=1 ;;
+    *) echo "未知参数: ${arg}"; exit 1 ;;
+  esac
 done
 
-# 3. PyInstaller
-echo "[2/4] PyInstaller 打包..."
-"$PYTHON" -m PyInstaller "$SCRIPT_DIR/videodevour.spec" \
-  --noconfirm --distpath "$DIST_DIR" --workpath /tmp/vd-pyinstaller-build
+# 未指定架构时按主机判断（Rosetta 下 uname -m 会返回 x86_64）
+if [ "${BUILD_ARM64}" -eq 0 ] && [ "${BUILD_X64}" -eq 0 ]; then
+  if [ "$(uname -m)" = "arm64" ]; then BUILD_ARM64=1; else BUILD_X64=1; fi
+fi
 
-# 4. 组装 .app
-echo "[3/4] 组装 .app 包..."
-rm -rf "$APP_BUNDLE"
-mkdir -p "$APP_BUNDLE/Contents/MacOS" "$APP_BUNDLE/Contents/Resources"
+# 1. 前端产物（两个架构共用，只构建一次）
+if [ ! -f "${PROJECT_ROOT}/frontend/dist/index.html" ]; then
+  echo "[前端] 构建中..."
+  (cd "${PROJECT_ROOT}/frontend" && npm run build)
+else
+  echo "[前端] 产物已存在，跳过"
+fi
 
-cat > "$APP_BUNDLE/Contents/Info.plist" <<'PLIST'
+build_one() {
+  local arch="$1"        # arm64 | x64
+  local target="$2"      # macos-arm64 | macos-x64
+  local py_var="$3"      # 环境变量名
+  local out_dir="${SCRIPT_DIR}/dist/${arch}"
+  local app_bundle="${out_dir}/${APP_NAME}.app"
+
+  local python="${!py_var:-}"
+  [ -z "${python}" ] && python="${PROJECT_ROOT}/.venv-$( [ "${arch}" = "x64" ] && echo x64 || echo lite )/bin/python"
+
+  echo ""
+  echo "=========================================="
+  echo "  构建 macOS ${arch}"
+  echo "  Python: ${python}"
+  echo "=========================================="
+
+  if [ ! -x "${python}" ]; then
+    echo "[错误] 找不到 ${arch} 的 Python 环境: ${python}"
+    echo "       请先创建（参考 desktop/README.md 的构建章节）"
+    exit 1
+  fi
+  # platform.machine() 返回 arm64 / x86_64，而脚本参数用 arm64 / x64
+  local actual expect
+  actual="$("${python}" -c 'import platform;print(platform.machine())')"
+  expect="$([ "${arch}" = "x64" ] && echo x86_64 || echo arm64)"
+  if [ "${actual}" != "${expect}" ]; then
+    echo "[错误] Python 架构不匹配：期望 ${expect}（${arch}），实际 ${actual}"
+    echo "       PyInstaller 输出的架构由解释器决定，必须用对应架构的 Python。"
+    exit 1
+  fi
+
+  # 检查捆绑二进制（按架构目录）
+  for bin in ffmpeg ffprobe; do
+    if [ ! -f "${SCRIPT_DIR}/bin/${target}/${bin}" ]; then
+      echo "[警告] 缺少 desktop/bin/${target}/${bin}，将回退系统 PATH"
+      echo "       可运行：desktop/fetch_binaries.sh ${target}"
+    fi
+  done
+
+  echo "[1/3] PyInstaller 打包（${arch}）..."
+  VD_TARGET="${target}" "${python}" -m PyInstaller "${SCRIPT_DIR}/videodevour.spec" \
+    --noconfirm --distpath "${out_dir}" --workpath "/tmp/vd-pyinstaller-build-${arch}"
+
+  echo "[2/3] 组装 .app（${arch}）..."
+  rm -rf "${app_bundle}"
+  mkdir -p "${app_bundle}/Contents/MacOS" "${app_bundle}/Contents/Resources"
+
+  cat > "${app_bundle}/Contents/Info.plist" <<'PLIST'
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
@@ -72,7 +119,7 @@ cat > "$APP_BUNDLE/Contents/Info.plist" <<'PLIST'
     <key>CFBundleExecutable</key>
     <string>VideoDevour</string>
     <key>LSMinimumSystemVersion</key>
-    <string>12.0</string>
+    <string>11.0</string>
     <key>NSHighResolutionCapable</key>
     <true/>
     <key>NSRequiresAquaSystemAppearance</key>
@@ -81,32 +128,39 @@ cat > "$APP_BUNDLE/Contents/Info.plist" <<'PLIST'
 </plist>
 PLIST
 
-# 资源全部放 Resources，MacOS 下只放启动脚本
-cp -R "$DIST_DIR/$APP_NAME/." "$APP_BUNDLE/Contents/Resources/"
+  cp -R "${out_dir}/${APP_NAME}/." "${app_bundle}/Contents/Resources/"
 
-cat > "$APP_BUNDLE/Contents/MacOS/$APP_NAME" <<'LAUNCH'
+  cat > "${app_bundle}/Contents/MacOS/${APP_NAME}" <<'LAUNCH'
 #!/bin/bash
 # .app 入口：启动同一可执行文件的壳角色（无参数）
 HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")/../Resources" && pwd)"
-exec "$HERE/VideoDevour" "$@"
+exec "${HERE}/VideoDevour" "$@"
 LAUNCH
-chmod +x "$APP_BUNDLE/Contents/MacOS/$APP_NAME"
+  chmod +x "${app_bundle}/Contents/MacOS/${APP_NAME}"
 
-# 5. 签名（可选）
-if [ "$DO_SIGN" = "--sign" ]; then
-  echo "[4/4] ad-hoc 签名..."
-  # 先签内部所有二进制/动态库，再签外层（顺序不能反）
-  find "$APP_BUNDLE/Contents/Resources" \( -name "*.so" -o -name "*.dylib" -o -name "ffmpeg" -o -name "ffprobe" -o -name "VideoDevour" \) \
-    -exec codesign --force --sign - {} \; 2>/dev/null || true
-  codesign --force --deep --sign - "$APP_BUNDLE"
-  echo "  已 ad-hoc 签名（正式分发需开发者证书 + 公证）"
-else
-  echo "[4/4] 跳过签名（加 --sign 启用 ad-hoc 签名）"
+  if [ "${DO_SIGN}" -eq 1 ]; then
+    echo "[3/3] ad-hoc 签名（${arch}）..."
+    # 先签内部所有二进制/动态库，再签外层（顺序不能反）
+    find "${app_bundle}/Contents/Resources" \
+      \( -name "*.so" -o -name "*.dylib" -o -name "ffmpeg" -o -name "ffprobe" -o -name "${APP_NAME}" \) \
+      -exec codesign --force --sign - {} \; 2>/dev/null || true
+    codesign --force --deep --sign - "${app_bundle}"
+  else
+    echo "[3/3] 跳过签名（加 --sign 启用）"
+  fi
+
+  echo "完成：${app_bundle}"
+  du -sh "${app_bundle}" | awk '{print "  体积: "$1}'
+  file "${app_bundle}/Contents/Resources/${APP_NAME}" | grep -oE "arm64|x86_64" | head -1 | sed 's/^/  可执行架构: /'
+}
+
+if [ "${BUILD_ARM64}" -eq 1 ]; then
+  build_one "arm64" "macos-arm64" "PYTHON_ARM64"
+fi
+if [ "${BUILD_X64}" -eq 1 ]; then
+  build_one "x64" "macos-x64" "PYTHON_X64"
 fi
 
 echo ""
-echo "构建完成：$APP_BUNDLE"
-du -sh "$APP_BUNDLE"
-echo ""
-echo "运行：open '$APP_BUNDLE'"
-echo "内测若被 Gatekeeper 拦截：xattr -cr '$APP_BUNDLE'"
+echo "全部完成。运行：open desktop/dist/<arch>/${APP_NAME}.app"
+echo "内测若被 Gatekeeper 拦截：xattr -cr '<app 路径>'"

--- a/desktop/build_mac.sh
+++ b/desktop/build_mac.sh
@@ -68,11 +68,13 @@ build_one() {
   echo "  Python: ${python}"
   echo "=========================================="
 
-  if [ ! -x "${python}" ]; then
+  # PYTHON_<ARCH> 可以是绝对路径，也可以是 PATH 上的命令名（CI 里传 "python"）
+  if ! command -v "${python}" >/dev/null 2>&1 && [ ! -x "${python}" ]; then
     echo "[错误] 找不到 ${arch} 的 Python 环境: ${python}"
-    echo "       请先创建（参考 desktop/README.md 的构建章节）"
+    echo "       请先创建（参考 desktop/README.md 的构建章节），或设置 PYTHON_$(echo "${arch}" | tr a-z A-Z)"
     exit 1
   fi
+  python="$(command -v "${python}" || echo "${python}")"
   # platform.machine() 返回 arm64 / x86_64，而脚本参数用 arm64 / x64
   local actual expect
   actual="$("${python}" -c 'import platform;print(platform.machine())')"

--- a/desktop/fetch_binaries.sh
+++ b/desktop/fetch_binaries.sh
@@ -1,55 +1,83 @@
 #!/bin/bash
-# 获取桌面包所需的静态 ffmpeg / ffprobe（放入 desktop/bin/）
+# 获取桌面包所需的静态 ffmpeg / ffprobe
 #
 # 用法：
-#   desktop/fetch_binaries.sh            # 按当前平台下载
-#   desktop/fetch_binaries.sh macos      # 强制 macOS arm64
-#   desktop/fetch_binaries.sh windows    # 强制 Windows x64
+#   desktop/fetch_binaries.sh                  # 按当前主机平台/架构下载
+#   desktop/fetch_binaries.sh macos-arm64      # macOS Apple Silicon
+#   desktop/fetch_binaries.sh macos-x64        # macOS Intel
+#   desktop/fetch_binaries.sh windows-x64      # Windows x64
+#   desktop/fetch_binaries.sh --all-macos      # macOS 双架构都下
 #
-# 来源：eugeneware/ffmpeg-static（静态构建，无 homebrew/系统库动态依赖，
-#       可直接随包分发；Homebrew 版本动态链接 18 个库，不可捆绑）。
+# 存放位置（按架构分目录，双架构可共存）：
+#   desktop/bin/<target>/ffmpeg[.exe]
+#
+# 来源：eugeneware/ffmpeg-static（静态构建，不依赖 homebrew/系统库，可随包分发；
+#       Homebrew 版本动态链接 18 个库，不可捆绑）。
 # 版本：b6.0（ffmpeg 6.0）。升级需重新验证切片/抽帧/音频提取。
 
 set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-BIN_DIR="$SCRIPT_DIR/bin"
+BIN_ROOT="${SCRIPT_DIR}/bin"
 BASE_URL="https://github.com/eugeneware/ffmpeg-static/releases/download/b6.0"
 
-TARGET="${1:-}"
-if [ -z "$TARGET" ]; then
-  case "$(uname -s)" in
-    Darwin) TARGET="macos" ;;
-    MINGW*|MSYS*|CYGWIN*) TARGET="windows" ;;
-    *) echo "未知平台，请显式指定 macos / windows"; exit 1 ;;
+# target 名 → ffmpeg-static 的 release 文件后缀
+suffix_for() {
+  case "$1" in
+    macos-arm64)   echo "darwin-arm64" ;;
+    macos-x64)     echo "darwin-x64" ;;
+    windows-x64)   echo "win32-x64" ;;
+    *) return 1 ;;
   esac
-fi
+}
 
-mkdir -p "$BIN_DIR"
+ext_for() {
+  case "$1" in
+    windows-*) echo ".exe" ;;
+    *)         echo "" ;;
+  esac
+}
 
-case "$TARGET" in
-  macos)
-    SUFFIX="darwin-arm64"; EXT=""
+fetch_target() {
+  local target="$1"
+  local suffix ext dir
+  suffix="$(suffix_for "${target}")" || { echo "不支持的目标: ${target}"; return 1; }
+  ext="$(ext_for "${target}")"
+  dir="${BIN_ROOT}/${target}"
+  mkdir -p "${dir}"
+
+  for tool in ffmpeg ffprobe; do
+    local dest="${dir}/${tool}${ext}"
+    if [ -f "${dest}" ]; then
+      echo "[跳过] ${target}/${tool}（已存在）"
+      continue
+    fi
+    echo "[下载] ${target}/${tool}  (${suffix})"
+    curl -fL --retry 3 -o "${dest}" "${BASE_URL}/${tool}-${suffix}"
+    chmod +x "${dest}" 2>/dev/null || true
+  done
+}
+
+TARGETS=()
+case "${1:-}" in
+  --all-macos) TARGETS=(macos-arm64 macos-x64) ;;
+  "") 
+    case "$(uname -s)-$(uname -m)" in
+      Darwin-arm64) TARGETS=(macos-arm64) ;;
+      Darwin-x86_64) TARGETS=(macos-x64) ;;
+      MINGW*|MSYS*|CYGWIN*) TARGETS=(windows-x64) ;;
+      *) echo "未知平台，请显式指定目标"; exit 1 ;;
+    esac
     ;;
-  windows)
-    SUFFIX="win32-x64"; EXT=".exe"
-    ;;
-  *)
-    echo "不支持的目标: $TARGET（可选 macos / windows）"; exit 1
-    ;;
+  *) TARGETS=("$1") ;;
 esac
 
-for tool in ffmpeg ffprobe; do
-  dest="$BIN_DIR/$tool$EXT"
-  if [ -f "$dest" ]; then
-    echo "[跳过] $dest 已存在"
-    continue
-  fi
-  echo "[下载] $tool ($SUFFIX)"
-  curl -fL --retry 3 -o "$dest" "$BASE_URL/$tool-$SUFFIX"
-  chmod +x "$dest" 2>/dev/null || true
+for t in "${TARGETS[@]}"; do
+  fetch_target "${t}"
 done
 
 echo ""
-echo "完成，当前 desktop/bin/："
-ls -la "$BIN_DIR"
+echo "完成，desktop/bin/ 现状："
+find "${BIN_ROOT}" -type f -not -name ".DS_Store" | sort | while read -r f; do
+  printf "  %s\n" "${f#"${BIN_ROOT}"/}"
+done

--- a/desktop/release/README-测试说明.md
+++ b/desktop/release/README-测试说明.md
@@ -1,6 +1,6 @@
 # VideoDevour 桌面客户端 · 测试包
 
-构建日期：2026-09-11　版本：0.1.0（轻量包）
+构建日期：2026-09-12　版本：0.1.0（轻量包）
 
 ## 交付文件
 
@@ -8,8 +8,10 @@
 |------|------|------|------|
 | `VideoDevour-0.1.0-setup.exe` | Windows x64 | 146MB | **推荐**：安装程序，含开始菜单/桌面快捷方式 |
 | `VideoDevour-windows-x64.zip` | Windows x64 | 203MB | 绿色版，解压即用（免安装） |
-| `VideoDevour-macos-arm64.zip` | macOS Apple Silicon | 195MB | 解压后得到 `VideoDevour.app` |
+| `VideoDevour-macos-arm64.zip` | macOS Apple Silicon | 195MB | M 系列芯片 |
+| `VideoDevour-macos-x64.zip` | macOS Intel | 175MB | Intel 芯片 |
 
+> **macOS 两个包按芯片选择**：M1/M2/M3/M4 用 `arm64`，Intel 用 `x64`。选错会打不开。
 > **绿色版必须解压后运行**：含 onedir 结构，不能只单独拿出 `.exe`。
 
 ## Windows 测试步骤

--- a/desktop/videodevour.spec
+++ b/desktop/videodevour.spec
@@ -9,6 +9,10 @@ VideoDevour 桌面客户端打包配置（PyInstaller onedir）
     dist/VideoDevour/            # 后端 + 壳 + 前端产物
     dist/VideoDevour.app         # macOS 应用包（在 build_mac.sh 中组装）
 
+架构选择（环境变量 VD_TARGET）：
+    不设置时按当前主机推断（darwin-arm64 / darwin-x64 / windows-x64）。
+    用于挑选 desktop/bin/<target>/ 下对应架构的 ffmpeg，避免混入错误架构的二进制。
+
 设计要点：
 - onedir 模式（非 onefile）：onefile 每次启动解压到临时目录，首启慢且杀软误报率高
 - 轻量依赖集合：不含 torch/funasr/modelscope/sentence-transformers
@@ -22,7 +26,23 @@ from PyInstaller.utils.hooks import collect_submodules, collect_data_files
 
 PROJECT_ROOT = Path(SPECPATH).resolve().parent
 FRONTEND_DIST = PROJECT_ROOT / "frontend" / "dist"
-BIN_DIR = PROJECT_ROOT / "desktop" / "bin"
+
+
+def _target():
+    """解析目标平台标识，与 desktop/bin/<target>/ 目录名一致。"""
+    explicit = os.environ.get("VD_TARGET")
+    if explicit:
+        return explicit
+    machine = os.uname().machine if hasattr(os, "uname") else ""
+    if sys.platform == "darwin":
+        return "macos-arm64" if machine == "arm64" else "macos-x64"
+    if sys.platform.startswith("win"):
+        return "windows-x64"
+    return "macos-arm64"
+
+
+TARGET = _target()
+BIN_DIR = PROJECT_ROOT / "desktop" / "bin" / TARGET
 
 datas = []
 
@@ -34,12 +54,18 @@ else:
         "缺少前端构建产物：请先执行 `cd frontend && npm run build`"
     )
 
-# 捆绑的 ffmpeg/ffprobe（可选：不存在时回退系统 PATH）
+# 捆绑的 ffmpeg/ffprobe：按目标架构目录取，避免双架构构建时取错
+# （可选：目录不存在时回退系统 PATH）
+_bin_ext = ".exe" if TARGET.startswith("windows") else ""
 if BIN_DIR.exists():
     for name in ("ffmpeg", "ffprobe"):
-        candidate = BIN_DIR / (name + (".exe" if sys.platform.startswith("win") else ""))
+        candidate = BIN_DIR / (name + _bin_ext)
         if candidate.exists():
             datas.append((str(candidate), "bin"))
+        else:
+            print(f"[spec] 警告: {TARGET} 缺少 {name}，将回退系统 PATH")
+else:
+    print(f"[spec] 警告: 找不到 {BIN_DIR}，将回退系统 PATH（请先运行 fetch_binaries.sh）")
 
 # uvicorn / fastapi 的动态导入需要显式收集
 hiddenimports = []

--- a/planning/A3-A4-构建验证报告.md
+++ b/planning/A3-A4-构建验证报告.md
@@ -204,6 +204,36 @@ ERROR - 无法初始化VLM处理器，跳过关键帧选择: No module named 'vl
 > **通用教训**：spec 里不要对无 `__init__.py` 的目录用 `collect_submodules`；
 > 项目内导入一律用绝对路径，避免依赖 `sys.path` 副作用（冻结后不成立）。
 
+### 4.5 Intel (x86_64) 包：cryptography OpenSSL 符号冲突（2026-09-12）
+
+新增 macOS Intel 构建时，x86_64 包在线 ASR 整体失败：
+
+```
+ERROR - [DashScope] ASR 处理失败: dlopen(.../cryptography/hazmat/bindings/_rust.abi3.so, 0x0002):
+        symbol not found in flat namespace '_BIO_ADDR_free'
+```
+
+**根因（wheel 与解释器的链接方式不匹配，与 PyInstaller 无关）**：
+
+- `cryptography` 的 macOS **x86_64 wheel（50.x）** 把 OpenSSL 符号（`_BIO_ADDR_free` 等）
+  留作**未定义**，期望运行时从进程空间动态解析 —— 实测该 so 有 5+ 个未定义 OpenSSL 符号
+- uv 提供的 x86_64 CPython **静态链接 OpenSSL 且不导出这些符号**（`nm -gU` 导出数为 0）
+- arm64 wheel 则把 OpenSSL 静态解析进自身（未定义符号数 0），因此 arm64 包不受影响
+
+由于 `dashscope`（在线 ASR）在运行时导入 `cryptography`，该错误只在"在线 ASR"链路触发。
+
+| # | 问题 | 修复 |
+|---|------|------|
+| 17 | x86_64 cryptography wheel 依赖动态 OpenSSL，与静态链接的 Python 冲突 | 锁定 `cryptography==46.0.4`（实测两架构 wheel 均无未定义 OpenSSL 符号） |
+
+**验证**：在 x86_64 环境逐一测试 50.0.1 / 46.0.4 / 45.0.7 / 44.0.1 / 43.0.3 的
+`cryptography.hazmat.bindings._rust` 导入：仅 50.0.1 失败，46.0.4 及更早均正常。
+锁定后 x86_64 冻结包端到端跑通：下载合并 → 在线 ASR → VLM 关键帧（4 张）→ 报告 → PDF（15 页），
+图片经 `/static/<out_dir>/keyframes/<中文名>` 返回 200 image/jpeg。
+
+> **通用教训**：为同一份代码构建多架构时，二进制 wheel 的链接方式可能不同 ——
+> 不要假设"arm64 能跑就等于 x86_64 能跑"，每个架构都要实际构建并跑通链路。
+
 ---
 
 ## 5. 已实现的能力（对照方案条款）

--- a/requirements-lite.txt
+++ b/requirements-lite.txt
@@ -22,6 +22,12 @@ mcp==1.17.0
 
 # --- 在线 ASR ---
 dashscope>=1.20.0
+# cryptography 由 dashscope 引入，必须上限约束（macOS x86_64 打包关键）：
+# 50.x 的 macOS x86_64 wheel 把 OpenSSL 符号留作未定义（期望运行时动态解析），
+# 而 uv 的 x86_64 Python 静态链接 OpenSSL 且不导出这些符号，
+# 导致 `symbol not found in flat namespace '_BIO_ADDR_free'`，在线 ASR 整体失败。
+# 46.0.4 实测两个架构的 wheel 均无未定义符号。详见 A3-A4 报告第 4.5 节。
+cryptography==46.0.4
 
 # --- 下载与字幕 ---
 yt-dlp[default]>=2024.8.6


### PR DESCRIPTION
## 内容

新增 macOS **Intel (x86_64)** 构建支持，并修复该架构下的一个真实缺陷。

### 构建脚本支持双架构

- `build_mac.sh` 支持 `--arm64` / `--x64` / `--both`，按架构校验 Python 并输出到独立目录（`dist/arm64/`、`dist/x64/`）
- `videodevour.spec` 按 `VD_TARGET` 选择 `desktop/bin/<target>/` 下的 ffmpeg，避免双架构构建时取错二进制
- `fetch_binaries.sh` 改为按架构分目录存放（`macos-arm64` / `macos-x64` / `windows-x64`）
- 修复脚本中 `$var` 紧跟中文导致的 bash 变量名解析错误（改用 `${var}`）
- 修复架构校验：`platform.machine()` 返回 `x86_64`，脚本参数用 `x64`

### 关键缺陷：x86_64 在线 ASR 全部失败

```
ERROR - [DashScope] ASR 处理失败: dlopen(.../cryptography/hazmat/bindings/_rust.abi3.so, 0x0002):
        symbol not found in flat namespace '_BIO_ADDR_free'
```

**根因**（与 PyInstaller 无关，是 wheel 与解释器的链接方式不匹配）：
- `cryptography` 的 macOS **x86_64 wheel（50.x）** 把 OpenSSL 符号留作**未定义**，期望运行时动态解析
- uv 的 x86_64 CPython **静态链接 OpenSSL 且不导出这些符号**
- arm64 wheel 则把 OpenSSL 静态解析进自身，因此 arm64 不受影响

`dashscope`（在线 ASR）在运行时导入 `cryptography`，所以只有在线 ASR 链路触发。

**修复**：锁定 `cryptography==46.0.4`（逐一测试 50.0.1 / 46.0.4 / 45.0.7 / 44.0.1 / 43.0.3，仅 50.0.1 失败）。

### CI

新增 macOS 双架构 job：`macos-14`（arm64）+ `macos-15-intel`（Intel，`macos-13` 已弃用会永久排队）。
Windows job 的 ffmpeg 下载路径同步改为新目录结构。

## 验证

CI run 34660411269：**arm64 ✅ / Intel x86_64 ✅ / Windows x64 ✅**

Intel 冻结包本机端到端验证（经 Rosetta）：
- 下载合并 → 在线 ASR → VLM 关键帧（4 张）→ 图文报告 → PDF 导出（15 页）
- 报告含图片引用，`/static/<out_dir>/keyframes/<中文名>` 返回 200 image/jpeg
- arm64 重建后无回归（ASR 连通性测试正常通过 cryptography 加载）

> ⚠️ Intel 与 Windows 包的业务链路均未在**对应真机**上验证（Intel 验证经 Rosetta，Windows 仅启动+health）。
