### PR TITLE
chore: 版本号升级至 0.1.1

### DIFF
--- a/desktop/build_mac.sh
+++ b/desktop/build_mac.sh
@@ -24,6 +24,9 @@ set -euo pipefail
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 PROJECT_ROOT="$(cd "${SCRIPT_DIR}/.." && pwd)"
 APP_NAME="VideoDevour"
+# 版本号单一来源：默认取 pyproject.toml，可用 APP_VERSION 覆盖
+APP_VERSION="${APP_VERSION:-$(sed -n 's/^version *= *"\(.*\)"/\1/p' "${PROJECT_ROOT}/pyproject.toml" | head -1)}"
+[ -z "${APP_VERSION}" ] && APP_VERSION="0.0.0"
 
 BUILD_ARM64=0
 BUILD_X64=0
@@ -101,7 +104,7 @@ build_one() {
   rm -rf "${app_bundle}"
   mkdir -p "${app_bundle}/Contents/MacOS" "${app_bundle}/Contents/Resources"
 
-  cat > "${app_bundle}/Contents/Info.plist" <<'PLIST'
+  cat > "${app_bundle}/Contents/Info.plist" <<PLIST
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
@@ -113,9 +116,9 @@ build_one() {
     <key>CFBundleIdentifier</key>
     <string>com.videodevour.app</string>
     <key>CFBundleVersion</key>
-    <string>0.1.0</string>
+    <string>${APP_VERSION}</string>
     <key>CFBundleShortVersionString</key>
-    <string>0.1.0</string>
+    <string>${APP_VERSION}</string>
     <key>CFBundlePackageType</key>
     <string>APPL</string>
     <key>CFBundleExecutable</key>

--- a/desktop/installer.iss
+++ b/desktop/installer.iss
@@ -9,7 +9,7 @@
 ; - 不对可执行文件做数字签名时，SmartScreen 会提示，属预期行为
 
 #define AppName "VideoDevour"
-#define AppVersion "0.1.0"
+#define AppVersion "0.1.1"
 #define AppPublisher "VideoDevour"
 #define AppExeName "VideoDevour.exe"
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "video-devour"
-version = "0.1.0"
+version = "0.1.1"
 requires-python = ">=3.12"
 dependencies = [
     "camel-ai>=0.2.75",


### PR DESCRIPTION
## 内容

版本号统一升级至 **0.1.1**（配合新增的 macOS Intel 支持发布）。

- `pyproject.toml`：`0.1.0` → `0.1.1`
- `desktop/installer.iss`：`AppVersion` → `0.1.1`（安装包文件名随之变为 `VideoDevour-0.1.1-setup.exe`）
- `desktop/build_mac.sh`：`Info.plist` 的版本号改为**从 `pyproject.toml` 读取**（单一来源）
  —— 之前硬编码 `0.1.0`，会与安装包版本不一致

## 验证

双架构重建后 `CFBundleShortVersionString` 均为 `0.1.1`，两包冒烟测试 health=200。
