### PR TITLE
fix(desktop): 修复 macOS 客户端下载附件导致白屏

### DIFF
--- a/desktop/shell.py
+++ b/desktop/shell.py
@@ -490,6 +490,13 @@ def main():
         logging.warning(f"创建 WebView2 数据目录失败，沿用默认: {e}")
         storage_path = None
 
+    # 启用 WebView 原生下载：
+    # pywebview 默认 ALLOW_DOWNLOADS=False，此时点击指向附件的链接（如报告/文章的
+    # 「下载 .md / PDF」）不会被当作下载，而是被 WebView 直接**导航**到该 URL，
+    # 整个 SPA 被文件内容替换 → 界面白屏（mac 实测）。
+    # 打开后走系统保存对话框；下载完成后由 IPC 事件刷新页面状态（见下）。
+    webview.settings['ALLOW_DOWNLOADS'] = True
+
     try:
         webview.start(private_mode=False, storage_path=storage_path)
     finally:

--- a/frontend/src/components/LibraryArticlePage.jsx
+++ b/frontend/src/components/LibraryArticlePage.jsx
@@ -63,6 +63,7 @@ function LibraryArticlePage() {
               <>
                 <a
                   href={`/api/library/article/${docId}/${scope}/download${runId ? `?run_id=${encodeURIComponent(runId)}&` : '?'}fmt=md`}
+                  download=""
                   className="flex items-center gap-1.5 px-4 py-2 rounded-lg bg-primary-600 text-white text-sm font-medium hover:bg-primary-700"
                 >
                   <Download className="w-4 h-4" />
@@ -70,6 +71,7 @@ function LibraryArticlePage() {
                 </a>
                 <a
                   href={`/api/library/article/${docId}/${scope}/download${runId ? `?run_id=${encodeURIComponent(runId)}&` : '?'}fmt=pdf`}
+                  download=""
                   className="flex items-center gap-1.5 px-4 py-2 rounded-lg border border-gray-300 text-gray-700 text-sm font-medium hover:bg-gray-50"
                 >
                   <FileDown className="w-4 h-4" />

--- a/frontend/src/components/LibraryPage.jsx
+++ b/frontend/src/components/LibraryPage.jsx
@@ -1,6 +1,7 @@
 import { useState, useEffect, useRef } from 'react'
 import { useNavigate } from 'react-router-dom'
 import { motion } from 'framer-motion'
+import { triggerDownload } from '../utils/helpers'
 import {
   ArrowLeft, BookOpen, Search, Loader2, FileText, Eye, Download, Zap, AlertCircle, Layers,
 } from 'lucide-react'
@@ -174,7 +175,7 @@ function LibraryPage() {
             <h1 className="text-lg font-bold text-gray-900">个人文档库</h1>
           </div>
           <button
-            onClick={() => window.open('/api/library/export', '_blank')}
+            onClick={() => triggerDownload('/api/library/export')}
             title="整库导出（按视频/版本组织的 md + 关键帧 + manifest.json）"
             className="report-tool-button"
           >

--- a/frontend/src/components/LibraryVideoPage.jsx
+++ b/frontend/src/components/LibraryVideoPage.jsx
@@ -211,11 +211,11 @@ function LibraryVideoPage() {
           <div className="flex items-center gap-2">
             {currentQuery && (
               <>
-                <a href={downloadHref} className="report-tool-button">
+                <a href={downloadHref} download="" className="report-tool-button">
                   <Download className="w-3.5 h-3.5" />
                   下载 .md
                 </a>
-                <a href={pdfHref} className="report-tool-button">
+                <a href={pdfHref} download="" className="report-tool-button">
                   <FileDown className="w-3.5 h-3.5" />
                   下载 PDF
                 </a>

--- a/frontend/src/components/ReportViewer.jsx
+++ b/frontend/src/components/ReportViewer.jsx
@@ -17,6 +17,7 @@ const STYLE_TABS = [
 ];
 const STYLE_KEYS = STYLE_TABS.map(t => t.key);
 import { generateCard, generateMindmap, generateKnowledgeGraph } from "../api/settingsService";
+import { triggerDownload } from "../utils/helpers";
 import ReactMarkdown from 'react-markdown';
 import remarkGfm from 'remark-gfm';
 import { mermaidMarkdownComponents } from './MermaidBlock';
@@ -162,7 +163,8 @@ const ReportViewer = ({ report, onBack, error, onRetry }) => {
     const url = mode === "pdf"
       ? `/api/export/${report.task_id}?type=${type}&fmt=pdf`
       : `/api/export/${report.task_id}?type=${type}&mode=${mode}`;
-    window.open(url, "_blank");
+    // 用带 download 属性的 <a> 触发：window.open 在桌面客户端里会静默无反应
+    triggerDownload(url);
     setExportMenu(null);
   };
 
@@ -513,8 +515,10 @@ const ReportViewer = ({ report, onBack, error, onRetry }) => {
           {isStyleTab ? (
             <div className="report-style-tools">
               <a href={`/api/library/article/${report.task_id}/${activeTab}/download?fmt=md`}
+                 download=""
                  className="report-tool-button"><FileText size={15} /> 下载 .md</a>
               <a href={`/api/library/article/${report.task_id}/${activeTab}/download?fmt=pdf`}
+                 download=""
                  className="report-tool-button"><FileDown size={15} /> 下载 PDF</a>
             </div>
           ) : (

--- a/frontend/src/utils/helpers.js
+++ b/frontend/src/utils/helpers.js
@@ -77,6 +77,30 @@ export const downloadFile = (content, filename, mimeType = "text/plain") => {
 };
 
 /**
+ * 触发浏览器/WebView 下载。
+ *
+ * 必须通过带 download 属性的 <a> 触发，不能用 window.open：
+ * - 桌面客户端（pywebview/WKWebView）：window.open 的导航类型是 Other，
+ *   不会被壳的「target=_blank 交给系统浏览器」逻辑接管，结果是静默无反应；
+ *   而不带 download 属性的链接会被 WebView 当作普通导航，
+ *   text/markdown、application/pdf 这类「可显示」的响应会把整个 SPA 替换掉 → 白屏。
+ *   带 download 属性后走 WebView 的下载策略（与 MIME 类型无关）。
+ * - 纯浏览器：效果等同普通下载。
+ *
+ * @param {string} url - 下载地址（同源相对路径即可）
+ */
+export const triggerDownload = (url) => {
+  const a = document.createElement("a");
+  a.href = url;
+  // 空值表示沿用响应 Content-Disposition 里的文件名（含中文）
+  a.download = "";
+  a.rel = "noopener";
+  document.body.appendChild(a);
+  a.click();
+  document.body.removeChild(a);
+};
+
+/**
  * 延迟函数
  * @param {number} ms - 延迟毫秒数
  * @returns {Promise}


### PR DESCRIPTION
## 问题（macOS 客户端实测反馈）

知识库点「下载 .md」后**界面白屏**；PDF / 整库 ZIP 等**点了没反应**。

## 根因

`pywebview` 的 `ALLOW_DOWNLOADS` 默认为 **`False`**（`webview/__init__.py`），而 macOS/WKWebView 的导航策略是：

```python
# webview/platforms/cocoa.py
if action.shouldPerformDownload() and webview_settings['ALLOW_DOWNLOADS']:
    handler(WKNavigationActionPolicyDownload); return
...
# 响应层
if navigationResponse.canShowMIMEType():
    decisionHandler(WKNavigationResponsePolicyAllow)   # ← 直接导航，替换掉 SPA
```

由于下载被禁，附件响应会**直接导航**——整个 SPA 被文件内容替换，即白屏。这同时解释了两种症状：

- `.md`（`text/markdown`，**可显示**）→ 导航过去 → **白屏**
- `.zip`（`application/zip`，**不可显示** + 下载被禁）→ 静默失败

## 修复

1. **壳**：启动前设 `webview.settings['ALLOW_DOWNLOADS'] = True`，走系统保存对话框
2. **前端**：所有下载锚点加 `download` 属性 —— 在 action 层即被识别为下载，**与 MIME 类型无关**，是防白屏的第一道防护
3. 新增 `utils/helpers.triggerDownload()`；把 2 处 `window.open` 改为 `<a download>` 触发（`window.open` 的导航类型为 `Other`，不会被壳的「新窗口交给系统浏览器」逻辑接管，在客户端内静默无反应）

覆盖入口：知识库文章页 / 视频页的 md+PDF、报告页 md+PDF、报告「导出报告」、「整库导出 ZIP」。

## 验证

最小复现（本地 HTTP 返回 `Content-Disposition: attachment`，用 pywebview 真实运行）：

| 状态 | 点击下载后 SPA 标记 | 结论 |
|---|---|---|
| `ALLOW_DOWNLOADS=False`（原始） | `null` | **页面被替换 → 复现白屏** |
| `ALLOW_DOWNLOADS=True`（修复） | `ALIVE` | 页面存活 → **已修复** |

另确认修复已进构建产物：前端主包含 `download=""` 与动态 `<a>` 创建逻辑；壳内 `ALLOW_DOWNLOADS=True`。三平台 CI 通过（run 34702189358）。
